### PR TITLE
Fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ venv/
 
 # Database
 db.sqlite3
+**/db.sqlite3
+**/__pycache__
 
 # macOS
 ._*


### PR DESCRIPTION
Fixes #15: **Fix .gitignore**

# Modification
This is just a minor update to the `.gitignore` file to make sure it excludes regular and outlying cache and database files.

- Earlier:
  ``` .gitignore
  ...
  db.sqlite3
  ...
  __pycache__
  ...
  ```
  
- Now:
  ``` .gitignore
  ...
  **/db.sqlite3
  ...
  **/__pycache__
  ...
  ```