### PR TITLE
feat: Forgot/Reset password

### DIFF
--- a/quizz/quizz/settings.py
+++ b/quizz/quizz/settings.py
@@ -127,3 +127,5 @@ STATICFILES_DIRS = [
 ]
 
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
+
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"

--- a/quizz/quizz/urls.py
+++ b/quizz/quizz/urls.py
@@ -22,6 +22,7 @@ from django.contrib.auth import views as auth_views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('reset/',include('django.contrib.auth.urls')),
     path('',include('question.urls')),
     path('register/',user_views.register,name='register'),
     path('login/',user_views.login,name='login'),

--- a/quizz/templates/registration/password_reset_complete.html
+++ b/quizz/templates/registration/password_reset_complete.html
@@ -1,0 +1,10 @@
+{% extends 'question/base.html' %}
+
+{% block title %}Password reset complete{% endblock %}
+
+{% block content %}
+<div class="cred">
+    <h2>Password reset complete</h2>
+    <h2>Your new password has been set. You can log in now on the <a href="{% url 'login' %}">log in page</a>.</h2>
+</div>
+{% endblock %}

--- a/quizz/templates/registration/password_reset_confirm.html
+++ b/quizz/templates/registration/password_reset_confirm.html
@@ -1,0 +1,26 @@
+{% extends 'question/base.html' %}
+
+{% block title %}Enter new password{% endblock %}
+
+{% block content %}
+
+<div class="cred">
+  {% if validlink %}
+
+  <h2>Set a new password!</h2>
+  <form method="POST">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" value="Change my password">Change password</button>
+  </form>
+
+  {% else %}
+
+  <h2>The password reset link was invalid, possibly because it has already been used. Please request a new password
+    reset.</h2>
+  <p class="muted">
+    Login here<a class="ml-2" href="{%url 'login' %}"> Login</a>
+  </p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/quizz/templates/registration/password_reset_done.html
+++ b/quizz/templates/registration/password_reset_done.html
@@ -1,0 +1,10 @@
+{% extends 'question/base.html' %}
+
+{% block title %}Email Sent{% endblock %}
+
+{% block content %}
+<div class="cred">
+  <h2>Check your inbox.</h2>
+  <h2>We've emailed you instructions for setting your password. You should receive the email shortly!</h2>
+</div>
+{% endblock %}

--- a/quizz/templates/registration/password_reset_form.html
+++ b/quizz/templates/registration/password_reset_form.html
@@ -1,0 +1,20 @@
+{% extends 'question/base.html' %}
+{% block title %}Forgot Your Password?{% endblock %}
+
+{% block content %}
+
+<div class="cred">
+  <h2>Enter your email address below, and we'll email instructions for setting a new one.</h2>
+    <form method="POST">
+      {% csrf_token %}
+      {{ form.as_p }}
+      <button type="submit" value="Reset">Reset</button>
+    </form>
+
+    <p class="muted">
+      New User?<a class="ml-2" href="{%url 'register' %}"> Sign Up</a> <br>
+      Login here<a class="ml-2" href="{%url 'login' %}"> Login</a> <br>
+    </p>
+</div>
+
+{% endblock %}

--- a/quizz/templates/users/login.html
+++ b/quizz/templates/users/login.html
@@ -22,7 +22,8 @@
     <button type="submit">Log in</button>
   </form>
   <p class="muted">
-    New User?<a class="ml-2" href="{%url 'register' %}"> Sign Up</a>
+    New User?<a class="ml-2" href="{%url 'register' %}"> Sign Up</a> <br>
+    Forgot password?<a class="ml-2" href="/reset/password_reset/"> Reset here</a>
   </p>
 </div>
 {% endblock content %}


### PR DESCRIPTION
**Issue fixed: #19** 

**Feature description:**
Reset password feature using `EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"` which sends a unique password reset link to the cli, opening which displays a password reset form.

**Screenshots**:

![signup](https://user-images.githubusercontent.com/46227193/101258761-9b725100-374a-11eb-862e-35764a9981b9.PNG)
![login](https://user-images.githubusercontent.com/46227193/101258755-97463380-374a-11eb-8352-f25211cc6cd9.PNG)
![reset1](https://user-images.githubusercontent.com/46227193/101258756-98776080-374a-11eb-9916-5dba56794518.PNG)
![reset2](https://user-images.githubusercontent.com/46227193/101258757-99a88d80-374a-11eb-9df1-b05723e8e37d.PNG)
![reset3](https://user-images.githubusercontent.com/46227193/101258759-9a412400-374a-11eb-90ac-19f51f441a88.PNG)
![reset4](https://user-images.githubusercontent.com/46227193/101258760-9ad9ba80-374a-11eb-988d-2dbebb73944a.PNG)