### PR TITLE
feat: auto-increment for question level

### DIFF
--- a/quizz/question/models.py
+++ b/quizz/question/models.py
@@ -11,11 +11,12 @@ class Question(models.Model):
         return self.question_text
     
     def save(self, *args, **kwargs):
-        last_level = Question.objects.all().aggregate(largest=models.Max('level'))['largest']
-        if last_level:
-            self.level = last_level+1
-        else:
-            self.level = 1
+        if not self.level:
+            last_level = Question.objects.all().aggregate(largest=models.Max('level'))['largest']
+            if last_level:
+                self.level = last_level+1
+            else:
+                self.level = 1
         super(Question, self).save(*args, **kwargs)
 
 class Choice(models.Model):

--- a/quizz/question/models.py
+++ b/quizz/question/models.py
@@ -9,6 +9,14 @@ class Question(models.Model):
 
     def __str__(self):
         return self.question_text
+    
+    def save(self, *args, **kwargs):
+        last_level = Question.objects.all().aggregate(largest=models.Max('level'))['largest']
+        if last_level:
+            self.level = last_level+1
+        else:
+            self.level = 1
+        super(Question, self).save(*args, **kwargs)
 
 class Choice(models.Model):
     question=models.ForeignKey(Question,on_delete=models.CASCADE)


### PR DESCRIPTION
# Related Issue
- #37

# Proposed Changes
- overrided the default `save` method for the `Question` model
- `level` for a question is no longer required to be manually added everytime by admin. The level will automatically set as 1 for first question and increment on every new question addition.

# Additional Info
- The older model definition is not changed, so that admin can update level of existing questions.


# Screenshots
![1](https://user-images.githubusercontent.com/46227193/102094826-c8a8b880-3e48-11eb-82df-b6172cf2b700.PNG)
![2](https://user-images.githubusercontent.com/46227193/102094835-ca727c00-3e48-11eb-9698-f98ec091cbca.PNG)
![3](https://user-images.githubusercontent.com/46227193/102094841-cba3a900-3e48-11eb-9788-cb8e1986e4d9.PNG)
![4](https://user-images.githubusercontent.com/46227193/102094842-cc3c3f80-3e48-11eb-8269-3b32b90336ff.PNG)
![5](https://user-images.githubusercontent.com/46227193/102094845-ccd4d600-3e48-11eb-89bf-2c40352bf104.PNG)
![6](https://user-images.githubusercontent.com/46227193/102094848-cd6d6c80-3e48-11eb-8467-e94e7c23f9d0.PNG)

